### PR TITLE
Implemented `clearOn`

### DIFF
--- a/packages/core/src/create-form.spec.ts
+++ b/packages/core/src/create-form.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fork, is, allSettled } from 'effector';
+import { fork, is, allSettled, createEvent } from 'effector';
 import { faker } from '@faker-js/faker';
 import { createForm } from './create-form';
 
@@ -469,5 +469,24 @@ describe('create-form', () => {
     expect(scope.getState(form.fields.email.$value)).toBe(initialValues.email);
     expect(scope.getState(form.fields.email.$isDirty)).toBe(false);
     expect(scope.getState(form.fields.email.$isValid)).toBe(false);
+  });
+
+  it ('must trigger form.cleared on clearOn', async () => {
+    const someEvent = createEvent();
+    const clearedFormSpy = vi.fn();
+
+    const simpleForm = createForm({
+      fields: {},
+      validator: () => ({ result: true }),
+      clearOn: [someEvent],
+    });
+
+    simpleForm.cleared.watch(clearedFormSpy);
+
+    await allSettled(someEvent, {
+      scope,
+    });
+
+    expect(clearedFormSpy).toBeCalledTimes(1);
   });
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,2 +1,6 @@
 export type AtLeastOne<T, U = { [K in keyof T]: Pick<T, K> }> = Partial<T> &
   U[keyof U];
+
+export interface NonEmptyArray<T> extends Array<T> {
+  0: T
+};

--- a/packages/yup/src/index.ts
+++ b/packages/yup/src/index.ts
@@ -3,12 +3,9 @@ import { Schema } from '@effective-forms/core';
 
 interface Config<T extends 
 ObjectSchema<object, AnyObject, object, "">
-> {
+> extends Pick<Schema<InferType<T>>, 'validateOn' | 'clearOn'> {
   schema: T;
   initialValues: InferType<T>;
-  validateOn?: {
-    change: boolean,
-  };
 }
 
 export function yupSchema<T extends
@@ -32,6 +29,7 @@ export function yupSchema<T extends
 
       return { result: true };
     },
+    clearOn: config.clearOn,
     validateOn: config.validateOn,
   };
 

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,5 +1,15 @@
 import { ZodObject, ZodTypeAny, baseObjectInputType, baseObjectOutputType, objectUtil, z } from 'zod';
 import { Schema, FailFormValidationResult } from '@effective-forms/core';
+
+type SchemaType<T extends {
+  [_: string]: 
+    | z.ZodString
+    | z.ZodNumber
+    | z.ZodBoolean 
+    | z.ZodEffects<z.ZodNumber, number, number>
+    | z.ZodEffects<z.ZodString, string, string>
+    | z.ZodEffects<z.ZodBoolean, boolean, boolean>
+  }> = ZodObject<T, "strip", ZodTypeAny, { [k_1 in keyof objectUtil.addQuestionMarks<baseObjectOutputType<T>, { [k in keyof baseObjectOutputType<T>]: undefined extends baseObjectOutputType<T>[k] ? never : k; }[keyof T]>]: objectUtil.addQuestionMarks<baseObjectOutputType<T>, { [k in keyof baseObjectOutputType<T>]: undefined extends baseObjectOutputType<T>[k] ? never : k; }[keyof T]>[k_1]; }, { [k_2 in keyof baseObjectInputType<T>]: baseObjectInputType<T>[k_2]; }>;
 interface Config<T extends {
   [_: string]: 
     | z.ZodString
@@ -8,13 +18,10 @@ interface Config<T extends {
     | z.ZodEffects<z.ZodNumber, number, number>
     | z.ZodEffects<z.ZodString, string, string>
     | z.ZodEffects<z.ZodBoolean, boolean, boolean>
-  }> {
-  schema: ZodObject<T, "strip", ZodTypeAny, { [k_1 in keyof objectUtil.addQuestionMarks<baseObjectOutputType<T>, { [k in keyof baseObjectOutputType<T>]: undefined extends baseObjectOutputType<T>[k] ? never : k; }[keyof T]>]: objectUtil.addQuestionMarks<baseObjectOutputType<T>, { [k in keyof baseObjectOutputType<T>]: undefined extends baseObjectOutputType<T>[k] ? never : k; }[keyof T]>[k_1]; }, { [k_2 in keyof baseObjectInputType<T>]: baseObjectInputType<T>[k_2]; }>;
+  }> extends Schema<z.infer<SchemaType<T>>> {
+  schema: SchemaType<T>;
   initialValues: {
     [key in keyof T]: T[key]['_type'];
-  };
-  validateOn?: {
-    change: boolean,
   };
 }
 
@@ -30,6 +37,7 @@ export function zodSchema<T extends {
   schema,
   initialValues,
   validateOn,
+  clearOn,
 }: Config<T>) {
   const finalSchema: Schema<{ [key in keyof T]: T[key]['_type'] }> = {
     fields: {} as Schema<{ [key in keyof T]: T[key]['_type'] }>["fields"],


### PR DESCRIPTION
Now you can pass `clearOn` to `createForm` config, which accepts an array of effector units. The form values will be cleared when one of the units passed to `clearOn` is triggered.
### Example
```ts
const someEvent = createEvent();

const form = createForm(
  zodSchema({
    schema: z.object({ email: z.string() }),
    initialValues: {
      email: '',
    },
    clearOn: [someEvent],
  }),
);

form.fields.email.changed('example');
form.fields.email.$value // === 'example'

someEvent();

form.fields.email.$value // === ''
```

